### PR TITLE
Reimplement B4VehicleData C structs as C++ classes

### DIFF
--- a/src/B4ConvexHull.cpp
+++ b/src/B4ConvexHull.cpp
@@ -1,200 +1,299 @@
 #include "B4ConvexHull.h"
 #include <cmath>
-#include <vector>
+#include <vector> // Keep for local std::vector like worldSpaceVertices
 #include <cstdint>
-#include <cstring> // For std::memset
+#include <cstring> // For std::memset, std::memcpy
 #include <algorithm> // For std::min and std::max
 #include <cstdio>    // For snprintf
-// #include <iostream> // For debug std::cout, commented out for submission
 
-//class CB4DebugManager {
-//public:
+// Placeholder/external dependencies - keep as is (likely commented out in original)
+// class CB4DebugManager {
+// public:
 //    void DrawLine(const GtMath::Vector3& from, const GtMath::Vector3& to, const GtMath::Vector4& color) { (void)from; (void)to; (void)color; }
 //    void DrawVectorText(const char* text, const GtMath::Vector3& pos, const GtMath::Matrix3x4& o, float s, const GtMath::Vector4& c) { (void)text;(void)pos;(void)o;(void)s;(void)c;}
-//};
-//CB4DebugManager gDebugManager;
-//namespace SomeGraphicsNamespace { GraphicsManagerData gGraphicsManager; }
+// };
+// CB4DebugManager gDebugManager; // Placeholder
+// namespace SomeGraphicsNamespace { struct GraphicsManagerData {}; GraphicsManagerData gGraphicsManager; } // Placeholder
 
-//B4ConvexHull::B4ConvexHull() {
-//    // Constructor in .h initializes vectors and basic members
-//}
 
-void B4ConvexHull::Fixup() {
-    if (!m_faceData.empty()) m_offsetFaces = reinterpret_cast<uintptr_t>(m_faceData.data()); else m_offsetFaces = 0;
-    if (!m_planeData.empty()) m_offsetPlanes = reinterpret_cast<uintptr_t>(m_planeData.data()); else m_offsetPlanes = 0;
-    if (!m_vertexData.empty()) m_offsetVertices = reinterpret_cast<uintptr_t>(m_vertexData.data()); else m_offsetVertices = 0;
-    if (!m_edgeData.empty()) m_offsetEdges = reinterpret_cast<uintptr_t>(m_edgeData.data()); else m_offsetEdges = 0;
-    if (!m_deformData.empty()) m_offsetDeformData = reinterpret_cast<uintptr_t>(m_deformData.data()); else m_offsetDeformData = 0;
-}
+// B4ConvexHull::FixUp() is now defined in B4ConvexHull.h, so no definition here.
 
 int64_t B4ConvexHull::CalculatePlaneData(int planeIndex) {
-    if (m_planeData.size() < static_cast<size_t>((planeIndex + 1) * 16)) { return reinterpret_cast<int64_t>(m_faceData.data() + planeIndex * 4); }
-    if (m_faceData.size() < static_cast<size_t>((planeIndex + 1) * 4)) { return reinterpret_cast<int64_t>(m_faceData.data() + planeIndex * 4); }
+    if (!pFaces || !pVertices || !pPlanes || planeIndex < 0 || static_cast<uint8_t>(planeIndex) >= m_numPlanes) {
+        return 0;
+    }
 
-    uint8_t* raw_faces_base = m_faceData.data();
-    uint8_t* raw_vertices_base = m_vertexData.data();
-    uint8_t* raw_planes_base = m_planeData.data();
-    uint8_t* current_face_ptr = raw_faces_base + planeIndex * 4;
+    uint8_t* current_face_ptr = pFaces + planeIndex * 4;
 
-    uint8_t v_idx0 = current_face_ptr[0]; uint8_t v_idx1 = current_face_ptr[1];
-    uint8_t v_idx2 = current_face_ptr[2]; uint8_t v_idx3 = current_face_ptr[3];
+    uint8_t v_idx0 = current_face_ptr[0];
+    uint8_t v_idx1 = current_face_ptr[1];
+    uint8_t v_idx2 = current_face_ptr[2];
 
-    if (v_idx0 >= m_numVertices || v_idx1 >= m_numVertices || v_idx2 >= m_numVertices || v_idx3 >= m_numVertices) { return reinterpret_cast<int64_t>(current_face_ptr); }
-    if (m_vertexData.size() < (std::max({v_idx0, v_idx1, v_idx2, v_idx3}) + 1) * 16) { return reinterpret_cast<int64_t>(current_face_ptr); }
+    if (v_idx0 >= m_numVertices || v_idx1 >= m_numVertices || v_idx2 >= m_numVertices) {
+        return reinterpret_cast<int64_t>(current_face_ptr);
+    }
 
-    GtMath::Vector4 v0_4d=GtMath::load_vec4(raw_vertices_base+v_idx0*16); GtMath::Vector3 p0={v0_4d.x,v0_4d.y,v0_4d.z};
-    GtMath::Vector4 v1_4d=GtMath::load_vec4(raw_vertices_base+v_idx1*16); GtMath::Vector3 p1={v1_4d.x,v1_4d.y,v1_4d.z};
-    GtMath::Vector4 v2_4d=GtMath::load_vec4(raw_vertices_base+v_idx2*16); GtMath::Vector3 p2={v2_4d.x,v2_4d.y,v2_4d.z};
-    GtMath::Vector4 v3_4d=GtMath::load_vec4(raw_vertices_base+v_idx3*16); GtMath::Vector3 p3={v3_4d.x,v3_4d.y,v3_4d.z};
+    GtMath::Vector4 v0_4d = GtMath::load_vec4(pVertices + v_idx0 * 16); GtMath::Vector3 p0 = {v0_4d.x, v0_4d.y, v0_4d.z};
+    GtMath::Vector4 v1_4d = GtMath::load_vec4(pVertices + v_idx1 * 16); GtMath::Vector3 p1 = {v1_4d.x, v1_4d.y, v1_4d.z};
+    GtMath::Vector4 v2_4d = GtMath::load_vec4(pVertices + v_idx2 * 16); GtMath::Vector3 p2 = {v2_4d.x, v2_4d.y, v2_4d.z};
 
-    GtMath::Vector3 edge02 = GtMath::subtract(p0, p2); GtMath::Vector3 edge31 = GtMath::subtract(p3, p1);
-    GtMath::Vector3 normal = GtMath::cross_product(edge02, edge31);
+    GtMath::Vector3 edge10 = GtMath::subtract(p1, p0);
+    GtMath::Vector3 edge20 = GtMath::subtract(p2, p0);
+    GtMath::Vector3 normal = GtMath::cross_product(edge10, edge20);
     float length_sq = GtMath::length_squared(normal);
 
-    if (length_sq < 2.3283064e-10f) { return reinterpret_cast<int64_t>(current_face_ptr); }
-    else {
+    if (length_sq < 2.3283064e-10f) {
+        return reinterpret_cast<int64_t>(current_face_ptr);
+    } else {
         normal = GtMath::normalize(normal);
         float d_val = GtMath::dot_product(normal, p0);
-        GtMath::store_plane(raw_planes_base + planeIndex * 16, normal, d_val);
+        GtMath::store_plane(pPlanes + planeIndex * 16, normal, d_val);
         return reinterpret_cast<int64_t>(current_face_ptr);
     }
 }
 
 void B4ConvexHull::MakeBoxFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB) {
-    uint8_t* raw_verts = m_vertexData.data(); uint8_t* raw_planes = m_planeData.data();
-    uint8_t* raw_faces = m_faceData.data(); uint8_t* raw_edges = m_edgeData.data();
+    // This function populates the embedded data arrays.
+    // It assumes that this B4ConvexHull instance's embedded arrays will be used.
+    // Call FixUp first to ensure pFaces, pVertices etc. point to the embedded arrays.
+    InitialiseVehicleHull(); // This calls FixUp which sets p* to m_*_embed.data() using _raw offsets.
+
+    if (!pVertices || !pPlanes || !pFaces || !pEdges) return; // Check if FixUp failed or pointers are null
+
     GtMath::Vector4 v[8];
-    v[0]={minB.x,minB.y,minB.z,1}; v[1]={maxB.x,minB.y,minB.z,1}; v[2]={minB.x,maxB.y,minB.z,1}; v[3]={maxB.x,maxB.y,minB.z,1};
-    v[4]={minB.x,minB.y,maxB.z,1}; v[5]={maxB.x,minB.y,maxB.z,1}; v[6]={minB.x,maxB.y,maxB.z,1}; v[7]={maxB.x,maxB.y,maxB.z,1};
-    for(int i=0;i<8;++i) GtMath::store_vec4(raw_verts+i*16,v[i]);
-    m_numVertices=8;
-    GtMath::store_plane(raw_planes+0*16,GtMath::kBodyFront,GtMath::kBodyFront.z*maxB.z);
-    GtMath::store_plane(raw_planes+1*16,GtMath::kBodyBack,GtMath::kBodyBack.z*minB.z);
-    GtMath::store_plane(raw_planes+2*16,GtMath::kBodyTop,GtMath::kBodyTop.y*maxB.y);
-    GtMath::store_plane(raw_planes+3*16,GtMath::kBodyBottom,GtMath::kBodyBottom.y*minB.y);
-    GtMath::store_plane(raw_planes+4*16,GtMath::kBodyRight,GtMath::kBodyRight.x*maxB.x);
-    GtMath::store_plane(raw_planes+5*16,GtMath::kBodyLeft,GtMath::kBodyLeft.x*minB.x);
-    m_numPlanes=6;
-    raw_faces[0]=0;raw_faces[1]=2;raw_faces[2]=3;raw_faces[3]=1; raw_faces[4]=4;raw_faces[5]=0;raw_faces[6]=1;raw_faces[7]=5;
-    raw_faces[8]=4;raw_faces[9]=6;raw_faces[10]=2;raw_faces[11]=0; raw_faces[12]=1;raw_faces[13]=3;raw_faces[14]=7;raw_faces[15]=5;
-    raw_faces[16]=2;raw_faces[17]=6;raw_faces[18]=7;raw_faces[19]=3; raw_faces[20]=5;raw_faces[21]=7;raw_faces[22]=6;raw_faces[23]=4;
-    uint8_t edges_init[] = {0,1,4,5,0,4,5,1,2,3,6,7,2,6,7,3,2,0,3,1,4,6,5,7}; // Matched subtask list
-    std::memcpy(raw_edges, edges_init, sizeof(edges_init));
-    m_numEdges=12; m_flags=0;
+    v[0] = {minB.x, minB.y, minB.z, 1.0f}; v[1] = {maxB.x, minB.y, minB.z, 1.0f};
+    v[2] = {minB.x, maxB.y, minB.z, 1.0f}; v[3] = {maxB.x, maxB.y, minB.z, 1.0f};
+    v[4] = {minB.x, minB.y, maxB.z, 1.0f}; v[5] = {maxB.x, minB.y, maxB.z, 1.0f};
+    v[6] = {minB.x, maxB.y, maxB.z, 1.0f}; v[7] = {maxB.x, maxB.y, maxB.z, 1.0f};
+    for (int i = 0; i < 8; ++i) GtMath::store_vec4(pVertices + i * 16, v[i]);
+    m_numVertices = 8;
+
+    GtMath::store_plane(pPlanes + 0 * 16, {0.0f, 0.0f, 1.0f}, maxB.z);
+    GtMath::store_plane(pPlanes + 1 * 16, {0.0f, 0.0f, -1.0f}, -minB.z);
+    GtMath::store_plane(pPlanes + 2 * 16, {0.0f, 1.0f, 0.0f}, maxB.y);
+    GtMath::store_plane(pPlanes + 3 * 16, {0.0f, -1.0f, 0.0f}, -minB.y);
+    GtMath::store_plane(pPlanes + 4 * 16, {1.0f, 0.0f, 0.0f}, maxB.x);
+    GtMath::store_plane(pPlanes + 5 * 16, {-1.0f, 0.0f, 0.0f}, -minB.x);
+    m_numPlanes = 6;
+
+    uint8_t faces_init[] = {
+        4,5,7,6,  // Front (+Z)
+        0,2,3,1,  // Back (-Z)
+        2,6,7,3,  // Top (+Y)
+        0,1,5,4,  // Bottom (-Y)
+        1,3,7,5,  // Right (+X)
+        0,4,6,2   // Left (-X)
+    };
+    // Ensure pFaces points to m_faceData_embed and is large enough (68 bytes)
+    if (sizeof(faces_init) <= m_faceData_embed.size()) {
+       std::memcpy(pFaces, faces_init, sizeof(faces_init));
+    }
+
+
+    uint8_t edges_init[] = {
+        0,1, 1,3, 3,2, 2,0,
+        4,5, 5,7, 7,6, 6,4,
+        0,4, 1,5, 2,6, 3,7
+    };
+    // Ensure pEdges points to m_edgeData_embed and is large enough (56 bytes)
+    if (sizeof(edges_init) <= m_edgeData_embed.size()) {
+       std::memcpy(pEdges, edges_init, sizeof(edges_init));
+    }
+    m_numEdges = 12;
+    m_flags = 0;
 }
 
 void B4ConvexHull::MakeFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB, EB4HullShape shape) {
-    if(shape==EB4HullShape::Cone) MakeConeFromBoundingBox(minB,maxB);
-    else if(shape==EB4HullShape::Boat) MakeBoatFromBoundingBox(minB,maxB);
-    else MakeBoxFromBoundingBox(minB,maxB);
+    if (shape == EB4HullShape::Cone) MakeConeFromBoundingBox(minB, maxB);
+    else if (shape == EB4HullShape::Boat) MakeBoatFromBoundingBox(minB, maxB);
+    else MakeBoxFromBoundingBox(minB, maxB);
 }
 
-void B4ConvexHull::MakeConeFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB) {(void)minB;(void)maxB;/*TODO*/}
-void B4ConvexHull::MakeBoatFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB) {(void)minB;(void)maxB;/*TODO*/}
+void B4ConvexHull::MakeConeFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB) { (void)minB; (void)maxB; /*TODO*/ }
+void B4ConvexHull::MakeBoatFromBoundingBox(const GtMath::Vector3& minB, const GtMath::Vector3& maxB) { (void)minB; (void)maxB; /*TODO*/ }
 
 bool B4ConvexHull::DeformHullVerts(GtMath::Vector3* pAvgPos, const GtMath::Vector3& refPos, const GtMath::Matrix3x4& defM, const GtMath::Matrix3x4* boneMs, const B4ConvexHull& origHull) {
-    if(!(m_flags&2))return false;
-    if(origHull.m_vertexData.size()<origHull.m_numVertices*16)return false;
-    if(m_vertexData.size()<origHull.m_numVertices*16)return false;
-    if(m_deformData.size()<origHull.m_numVertices*12)return false;
-    uint8_t* defVertsPtr=m_vertexData.data(); const uint8_t* origVertsPtr=origHull.m_vertexData.data();
-    const uint8_t* deformDataPtr=m_deformData.data(); m_numVertices=origHull.m_numVertices;
-    for(uint8_t i=0;i<m_numVertices;++i){
-        GtMath::Matrix3x4 accumBoneM; float totalW=0.0f;
-        const uint8_t* curDeformEntry=deformDataPtr+i*12;
-        const float* Ws=reinterpret_cast<const float*>(curDeformEntry);
-        const uint8_t* boneIs=curDeformEntry+8;
-        for(int j=0;j<2;++j){
-            float w=Ws[j]; if(w==0.0f)continue; totalW+=w; uint8_t bIdx=boneIs[j];
-            const GtMath::Matrix3x4&bMRef=boneMs[bIdx];
-            GtMath::Matrix3x4 weightedBM=GtMath::matrix_multiply_scalar(bMRef,w);
-            accumBoneM=GtMath::matrix_add(accumBoneM,weightedBM);
-        }
-        float defMW=1.0f-totalW; GtMath::Matrix3x4 finalM=accumBoneM;
-        if(defMW>1e-6f){
-            GtMath::Matrix3x4 weightedDefM=GtMath::matrix_multiply_scalar(defM,defMW);
-            finalM=GtMath::matrix_add(finalM,weightedDefM);
-        }
-        GtMath::Vector4 oV4=GtMath::load_vec4(origVertsPtr+i*16); GtMath::Vector3 oPos={oV4.x,oV4.y,oV4.z};
-        GtMath::Vector3 defPos=GtMath::transform_point(finalM,oPos);
-        GtMath::Vector4 defV4={defPos.x,defPos.y,defPos.z,oV4.w};
-        GtMath::store_vec4(defVertsPtr+i*16,defV4);
+    if (!pVertices || !pDeformData || !origHull.pVertices || !boneMs) { // Added null check for boneMs
+        return false;
     }
+    if (!(m_flags & 2)) return false;
+
+    m_numVertices = origHull.m_numVertices;
+    m_numPlanes = origHull.m_numPlanes;
+    m_numEdges = origHull.m_numEdges;
+
+    for (uint8_t i = 0; i < m_numVertices; ++i) {
+        GtMath::Matrix3x4 accumBoneM = {};
+        float totalW = 0.0f;
+
+        const uint8_t* curDeformEntry = pDeformData + i * 12;
+        const float* Ws = reinterpret_cast<const float*>(curDeformEntry);
+        const uint8_t* boneIs = curDeformEntry + 8;
+
+        for (int j = 0; j < 2; ++j) {
+            float w = Ws[j];
+            if (w == 0.0f) continue;
+            totalW += w;
+            uint8_t bIdx = boneIs[j];
+            // TODO: Add check for bIdx against number of available boneMs if that count is known
+            const GtMath::Matrix3x4& bMRef = boneMs[bIdx];
+            GtMath::Matrix3x4 weightedBM = GtMath::matrix_multiply_scalar(bMRef, w);
+            accumBoneM = GtMath::matrix_add(accumBoneM, weightedBM);
+        }
+
+        float defMW = 1.0f - totalW;
+        GtMath::Matrix3x4 finalM = accumBoneM; // Use default constructor for GtMatrix3x4 if it initializes to zero
+        if (std::abs(defMW) > 1e-6f) { // Check if defMW is significantly non-zero
+            GtMath::Matrix3x4 weightedDefM = GtMath::matrix_multiply_scalar(defM, defMW);
+            if (totalW == 0.0f) { // If no bone weights, finalM is just weightedDefM
+                finalM = weightedDefM;
+            } else { // Else add to existing bone influences
+                finalM = GtMath::matrix_add(finalM, weightedDefM);
+            }
+        } else if (totalW == 0.0f) { // No bone weights and no default matrix weight
+             // finalM remains zero or identity depending on GtMatrix3x4 constructor.
+             // If it should be identity for passthrough:
+             // finalM = GtMath::Matrix3x4(true); // Assuming constructor for identity
+        }
+
+
+        GtMath::Vector4 oV4 = GtMath::load_vec4(origHull.pVertices + i * 16);
+        GtMath::Vector3 oPos = {oV4.x, oV4.y, oV4.z};
+        GtMath::Vector3 defPos = GtMath::transform_point(finalM, oPos);
+        GtMath::Vector4 defV4 = {defPos.x, defPos.y, defPos.z, oV4.w};
+        GtMath::store_vec4(pVertices + i * 16, defV4);
+    }
+
     MakePlanar();
-    if(pAvgPos){pAvgPos->x=0;pAvgPos->y=0;pAvgPos->z=0;(void)refPos;}
+
+    if (pAvgPos) {
+        pAvgPos->x = 0; pAvgPos->y = 0; pAvgPos->z = 0;
+        if (m_numVertices > 0) {
+            for (uint8_t i = 0; i < m_numVertices; ++i) {
+                GtMath::Vector4 v4 = GtMath::load_vec4(pVertices + i * 16);
+                pAvgPos->x += v4.x; pAvgPos->y += v4.y; pAvgPos->z += v4.z;
+            }
+            float invNumVerts = 1.0f / m_numVertices;
+            pAvgPos->x *= invNumVerts; pAvgPos->y *= invNumVerts; pAvgPos->z *= invNumVerts;
+        }
+        (void)refPos;
+    }
     return true;
 }
 
 void B4ConvexHull::MakePlanar() {
-    if(m_numVertices<16||m_vertexData.size()<16*16)return;
-    uint8_t*rawVerts=m_vertexData.data();
-    auto op=[&](int vA,int vB,int comp,bool minOp){
-        GtMath::Vector4 va=GtMath::load_vec4(rawVerts+vA*16); GtMath::Vector4 vb=GtMath::load_vec4(rawVerts+vB*16);
-        float*pA=(comp==0)?&va.x:(comp==1)?&va.y:&va.z; float*pB=(comp==0)?&vb.x:(comp==1)?&vb.y:&vb.z;
-        float res=minOp?std::min(*pA,*pB):std::max(*pA,*pB); *pA=res;*pB=res;
-        GtMath::store_vec4(rawVerts+vA*16,va); GtMath::store_vec4(rawVerts+vB*16,vb);
+    if (!pVertices || !pPlanes) return;
+    if (m_numVertices < 16) return;
+
+    auto op = [&](int vA_idx, int vB_idx, int component_idx, bool use_min_op) {
+        GtMath::Vector4 vA = GtMath::load_vec4(pVertices + vA_idx * 16);
+        GtMath::Vector4 vB = GtMath::load_vec4(pVertices + vB_idx * 16);
+        float* pValA = (component_idx == 0) ? &vA.x : (component_idx == 1) ? &vA.y : &vA.z;
+        float* pValB = (component_idx == 0) ? &vB.x : (component_idx == 1) ? &vB.y : &vB.z;
+        float result_val = use_min_op ? std::min(*pValA, *pValB) : std::max(*pValA, *pValB);
+        *pValA = result_val; *pValB = result_val;
+        GtMath::store_vec4(pVertices + vA_idx * 16, vA);
+        GtMath::store_vec4(pVertices + vB_idx * 16, vB);
     };
-    op(0,2,0,1);op(0,2,2,1); op(4,6,0,1);op(4,6,2,1); op(8,10,0,1);op(8,10,2,1); op(12,14,0,1);op(12,14,2,1);
-    op(1,3,0,0);op(1,3,2,0); op(5,7,0,0);op(5,7,2,0); op(9,11,0,0);op(9,11,2,1); op(13,15,0,0);op(13,15,2,1);
-    op(0,1,1,0); op(4,5,1,0); op(8,9,1,0); op(12,13,1,0);
-    op(2,3,1,1); op(6,7,1,1); op(10,11,1,1); op(14,15,1,1);
-    if(m_numPlanes>0){for(uint8_t i=0;i<m_numPlanes;++i)CalculatePlaneData(i);}
+
+    op(0,2,0,true); op(0,2,2,true); op(4,6,0,true); op(4,6,2,true);
+    op(8,10,0,true); op(8,10,2,true); op(12,14,0,true); op(12,14,2,true);
+    op(1,3,0,false); op(1,3,2,false); op(5,7,0,false); op(5,7,2,false);
+    // Original C++ had op(9,11,2,true) and op(13,15,2,true); keeping 'true' for Z component
+    op(9,11,0,false); op(9,11,2,true); op(13,15,0,false); op(13,15,2,true);
+    op(0,1,1,false); op(4,5,1,false); op(8,9,1,false); op(12,13,1,false);
+    op(2,3,1,true); op(6,7,1,true); op(10,11,1,true); op(14,15,1,true);
+
+    if (m_numPlanes > 0) {
+        for (uint8_t i = 0; i < m_numPlanes; ++i) {
+            CalculatePlaneData(i);
+        }
+    }
 }
 
 void B4ConvexHull::DebugRenderEdges(const GtMath::Matrix3x4& worldTF, bool drawTxt) const {
-    if(m_numVertices==0||m_numEdges==0)return;
-    std::vector<GtMath::Vector3> worldV(m_numVertices);
-    const uint8_t*localVPtr=m_vertexData.data();
-    for(uint8_t i=0;i<m_numVertices;++i){
-        GtMath::Vector4 lV4=GtMath::load_vec4(localVPtr+i*16); GtMath::Vector3 lPos={lV4.x,lV4.y,lV4.z};
-        worldV[i]=GtMath::transform_point(worldTF,lPos);
+    if (!pVertices || !pEdges || m_numVertices == 0 || m_numEdges == 0) return;
+
+    std::vector<GtMath::Vector3> worldSpaceVertices(m_numVertices);
+    for (uint8_t i = 0; i < m_numVertices; ++i) {
+        GtMath::Vector4 localVert4 = GtMath::load_vec4(pVertices + i * 16);
+        GtMath::Vector3 localPos = {localVert4.x, localVert4.y, localVert4.z};
+        worldSpaceVertices[i] = GtMath::transform_point(worldTF, localPos);
     }
-    const uint8_t*edgeDPtr=m_edgeData.data();
-    /*for(uint8_t eIdx=0;eIdx<m_numEdges;++eIdx){
-        uint8_t vIdx0=edgeDPtr[eIdx*2+0]; uint8_t vIdx1=edgeDPtr[eIdx*2+1];
-        if(vIdx0>=m_numVertices||vIdx1>=m_numVertices)continue;
-        const auto&p1=worldV[vIdx0]; const auto&p2=worldV[vIdx1];
-        gDebugManager.DrawLine(p1,p2,{1,1,0,1});
-        if(drawTxt){char buf[64];std::snprintf(buf,sizeof(buf),"E%d V%d-V%d",eIdx,vIdx0,vIdx1);
-            GtMath::Matrix3x4 dummyOrient(true); GtMath::Vector3 mid=GtMath::multiply_scalar(GtMath::add(p1,p2),0.5f);
-            gDebugManager.DrawVectorText(buf,mid,dummyOrient,0.1f,{1,1,1,1});}
-    }*/
+
+    /* // Debug rendering code using gDebugManager - keep commented if gDebugManager is not available
+    for (uint8_t edgeIdx = 0; edgeIdx < m_numEdges; ++edgeIdx) {
+        // Assuming pEdges stores pairs of uint8_t vertex indices
+        uint8_t vIdx0 = pEdges[edgeIdx * 2 + 0];
+        uint8_t vIdx1 = pEdges[edgeIdx * 2 + 1];
+
+        if (vIdx0 >= m_numVertices || vIdx1 >= m_numVertices) continue;
+
+        const auto& p1 = worldSpaceVertices[vIdx0];
+        const auto& p2 = worldSpaceVertices[vIdx1];
+        // gDebugManager.DrawLine(p1, p2, {1.0f, 1.0f, 0.0f, 1.0f});
+
+        if (drawTxt) {
+            char buf[64];
+            std::snprintf(buf, sizeof(buf), "E%d V%d-V%d", edgeIdx, vIdx0, vIdx1);
+            GtMath::Matrix3x4 dummyOrient(true);
+            GtMath::Vector3 midPoint = GtMath::multiply_scalar(GtMath::add(p1, p2), 0.5f);
+            // gDebugManager.DrawVectorText(buf, midPoint, dummyOrient, 0.1f, {1.0f, 1.0f, 1.0f, 1.0f});
+        }
+    }
+    */
+    (void)worldTF; (void)drawTxt;
 }
 
 void B4ConvexHull::DebugRenderPlanes(const GtMath::Matrix3x4& worldTF, bool drawTxt) const {
-    if(m_numVertices==0||m_numPlanes==0)return;
-    std::vector<GtMath::Vector3> worldV(m_numVertices);
-    const uint8_t*localVPtr=m_vertexData.data();
-    for(uint8_t i=0;i<m_numVertices;++i){
-        GtMath::Vector4 lV4=GtMath::load_vec4(localVPtr+i*16); GtMath::Vector3 lPos={lV4.x,lV4.y,lV4.z};
-        worldV[i]=GtMath::transform_point(worldTF,lPos);
+    if (!pVertices || !pPlanes || !pFaces || m_numVertices == 0 || m_numPlanes == 0) return;
+
+    std::vector<GtMath::Vector3> worldSpaceVertices(m_numVertices);
+    for (uint8_t i = 0; i < m_numVertices; ++i) {
+        GtMath::Vector4 localVert4 = GtMath::load_vec4(pVertices + i * 16);
+        GtMath::Vector3 localPos = {localVert4.x, localVert4.y, localVert4.z};
+        worldSpaceVertices[i] = GtMath::transform_point(worldTF, localPos);
     }
-    const uint8_t*planeDPtr=m_planeData.data(); const uint8_t*faceDPtr=m_faceData.data();
-    /*for(uint8_t pIdx=0;pIdx<m_numPlanes;++pIdx){
-        GtMath::Plane lPlane=GtMath::load_plane(planeDPtr+pIdx*16);
-        GtMath::Vector3 nl={lPlane.normal_x,lPlane.normal_y,lPlane.normal_z}; float dl=lPlane.d;
-        GtMath::Vector3 nwUnnorm=GtMath::transform_normal(nl,worldTF); GtMath::Vector3 nw=GtMath::normalize(nwUnnorm);
-        GtMath::Vector3 pLocalOnPlane=GtMath::multiply_scalar(nl,dl);
-        GtMath::Vector3 pWorldOnPlane=GtMath::transform_point(worldTF,pLocalOnPlane);
-        float dw=GtMath::dot_product(nw,pWorldOnPlane);
-        GtMath::Vector3 faceCenter={0,0,0}; uint8_t numFaceV=0;
-        if(m_faceData.size()>=(pIdx+1)*4){
-            const uint8_t*faceVIdxs=faceDPtr+pIdx*4;
-            for(int k=0;k<4;++k){if(faceVIdxs[k]<m_numVertices){faceCenter=GtMath::add(faceCenter,worldV[faceVIdxs[k]]);numFaceV++;}}
+
+    /* // Debug rendering code using gDebugManager
+    for (uint8_t planeIdx = 0; planeIdx < m_numPlanes; ++planeIdx) {
+        GtMath::Plane localPlane = GtMath::load_plane(pPlanes + planeIdx * 16);
+        GtMath::Vector3 localNormal = {localPlane.normal_x, localPlane.normal_y, localPlane.normal_z};
+
+        GtMath::Vector3 worldNormalUnnormalized = GtMath::transform_normal(localNormal, worldTF);
+        GtMath::Vector3 worldNormal = GtMath::normalize(worldNormalUnnormalized);
+
+        GtMath::Vector3 pointOnLocalPlane = GtMath::multiply_scalar(localNormal, localPlane.d);
+        GtMath::Vector3 pointOnWorldPlane = GtMath::transform_point(worldTF, pointOnLocalPlane);
+        float world_d = GtMath::dot_product(worldNormal, pointOnWorldPlane);
+
+        GtMath::Vector3 faceCenterWorld = pointOnWorldPlane;
+        uint8_t numFaceVerts = 0;
+        const uint8_t* faceVertexIndices = pFaces + planeIdx * 4;
+        GtMath::Vector3 tempFaceCenter = {0,0,0};
+        for (int k = 0; k < 4; ++k) { // Assuming 4 vertices per face from pFaces
+            if (faceVertexIndices[k] < m_numVertices) {
+                tempFaceCenter = GtMath::add(tempFaceCenter, worldSpaceVertices[faceVertexIndices[k]]);
+                numFaceVerts++;
+            }
         }
-        if(numFaceV>0)faceCenter=GtMath::multiply_scalar(faceCenter,1.0f/numFaceV); else faceCenter=pWorldOnPlane;
-        gDebugManager.DrawLine(faceCenter,GtMath::add(faceCenter,GtMath::multiply_scalar(nw,0.5f)),{0,1,1,1});
-        if(drawTxt){char buf[128];std::snprintf(buf,sizeof(buf),"P%d N(%.1f,%.1f,%.1f) D(%.1f)",pIdx,nw.x,nw.y,nw.z,dw);
+        if (numFaceVerts > 0) {
+            faceCenterWorld = GtMath::multiply_scalar(tempFaceCenter, 1.0f / numFaceVerts);
+        }
+
+        // gDebugManager.DrawLine(faceCenterWorld, GtMath::add(faceCenterWorld, GtMath::multiply_scalar(worldNormal, 0.5f)), {0.0f, 1.0f, 1.0f, 1.0f});
+
+        if (drawTxt) {
+            char buf[128];
+            std::snprintf(buf, sizeof(buf), "P%d N(%.1f,%.1f,%.1f) D(%.1f)", planeIdx, worldNormal.x, worldNormal.y, worldNormal.z, world_d);
             GtMath::Matrix3x4 dummyOrient(true);
-            gDebugManager.DrawVectorText(buf,faceCenter,dummyOrient,0.1f,{1,1,1,1});}
-    }*/
+            // gDebugManager.DrawVectorText(buf, faceCenterWorld, dummyOrient, 0.1f, {1.0f, 1.0f, 1.0f, 1.0f});
+        }
+    }
+    */
+    (void)worldTF; (void)drawTxt;
 }
 
 void B4ConvexHull::InitialiseVehicleHull() {
-    // This function in C sets the m_offset* members to point to the
-    // embedded data arrays (m_faceData, m_planeData, etc.) within the struct.
-    // Our Fixup() method achieves the same goal for the C++ class structure,
-    // where m_offset* members (uintptr_t) are set to the .data() addresses
-    // of their corresponding std::vector members.
-    this->Fixup();
+    FixUp(reinterpret_cast<char*>(this));
 }

--- a/src/B4ConvexHull.h
+++ b/src/B4ConvexHull.h
@@ -1,97 +1,122 @@
-#ifndef B4_CONVEX_HULL_H
-#define B4_CONVEX_HULL_H
+#pragma once
 
 #include <cstdint>
-#include <vector>
-#include "GtMath.h"
+#include <array>    // For std::array
+#include "GtMath.h" // For GtMath::Vector3, GtMath::Matrix3x4, etc.
 
-// Forward declare Debug Manager (assuming it's a class)
-class CB4DebugManager;
-extern CB4DebugManager gDebugManager; // Assuming global instance
+// Forward declarations like CB4DebugManager and SomeGraphicsNamespace are omitted
+// as they are not part of this struct's definition.
 
-// Forward declare Graphics Manager related structures (highly speculative)
-namespace SomeGraphicsNamespace { // Placeholder
-    struct GraphicsManagerData {
-        float someMatrixOrArray[16]; // Placeholder for whatever unknown_09+104 is
-    };
-    extern GraphicsManagerData gGraphicsManager; // Assuming global instance
-}
+namespace Burnout4 {
 
-
+// Enum from original file
 enum class EB4HullShape {
     Box = 0,
     Cone = 1,
     Boat = 2
-    // Future shapes might be added here
 };
 
 class B4ConvexHull {
 public:
-    // Pointer-like offsets
-    uintptr_t m_offsetFaces;
-    uintptr_t m_offsetPlanes;
-    uintptr_t m_offsetVertices;
-    uintptr_t m_offsetEdges;
-    uintptr_t m_offsetDeformData;
+    // These fields store the 4-byte offsets as they would be in the C struct data.
+    // These offsets are relative to the base of this B4ConvexHull instance.
+    uint32_t m_offsetFaces_raw;
+    uint32_t m_offsetPlanes_raw;
+    uint32_t m_offsetVertices_raw;
+    uint32_t m_offsetEdges_raw;
+    uint32_t m_offsetDeformData_raw;
 
-    // Flags and counts
     uint32_t m_flags;
-    uint8_t m_numVertices;
-    uint8_t m_numPlanes;
-    uint8_t m_numEdges;
-    uint8_t m_padding_or_unused1B; // To maintain struct alignment/size
+    uint8_t  m_numVertices;
+    uint8_t  m_numPlanes;
+    uint8_t  m_numEdges;
+    uint8_t  m_padding_or_unused1B; // To match C struct's 0x1B byte
 
-    // Data storage using std::vector<uint8_t> to represent byte arrays
-    // Sizes are based on the C struct's char arrays
-    std::vector<uint8_t> m_faceData;    // size 68 in C struct (B4Face[4])
-    std::vector<uint8_t> m_planeData;   // size 224 in C struct (GtMath::Plane[14])
-    std::vector<uint8_t> m_vertexData;  // size 256 in C struct (GtMath::Vector3[16])
-    std::vector<uint8_t> m_edgeData;    // size 56 in C struct (B4Edge[14])
-    std::vector<uint8_t> m_deformData;  // size 200 in C struct (B4Deform[10])
+    // Embedded data arrays, matching the C struct's layout and size (0x340 total for B4ConvexHull)
+    // Base offset for these arrays is 0x1C from the start of B4ConvexHull.
+    std::array<uint8_t, 68>  m_faceData_embed;     // Offset 0x1C. Size 68 (0x44)
+    std::array<uint8_t, 224> m_planeData_embed;    // Offset 0x60. Size 224 (0xE0)
+    std::array<uint8_t, 256> m_vertexData_embed;   // Offset 0x140. Size 256 (0x100)
+    std::array<uint8_t, 56>  m_edgeData_embed;     // Offset 0x240. Size 56 (0x38)
+    std::array<uint8_t, 200> m_deformData_embed;   // Offset 0x278. Size 200 (0xC8)
 
-    // Constructor to initialize vectors with correct sizes
+    // Resolved pointers for C++ convenience (populated by FixUp).
+    // These are not part of the 0x340 byte memory layout.
+    uint8_t* pFaces;
+    uint8_t* pPlanes;
+    uint8_t* pVertices;
+    uint8_t* pEdges;
+    uint8_t* pDeformData;
+
     B4ConvexHull() :
-        m_offsetFaces(0),
-        m_offsetPlanes(0),
-        m_offsetVertices(0),
-        m_offsetEdges(0),
-        m_offsetDeformData(0),
+        // Default raw offsets point to the embedded data arrays.
+        // Start of embedded data is at offset 0x1C (28 decimal) from the base of B4ConvexHull.
+        m_offsetFaces_raw(28),
+        m_offsetPlanes_raw(28 + 68),
+        m_offsetVertices_raw(28 + 68 + 224),
+        m_offsetEdges_raw(28 + 68 + 224 + 256),
+        m_offsetDeformData_raw(28 + 68 + 224 + 256 + 56),
         m_flags(0),
-        m_numVertices(0),
-        m_numPlanes(0),
-        m_numEdges(0),
-        m_padding_or_unused1B(0),
-        m_faceData(68),
-        m_planeData(224),
-        m_vertexData(256),
-        m_edgeData(56),
-        m_deformData(200)
-    {}
+        m_numVertices(0), m_numPlanes(0), m_numEdges(0), m_padding_or_unused1B(0),
+        pFaces(nullptr), pPlanes(nullptr), pVertices(nullptr), pEdges(nullptr), pDeformData(nullptr)
+    {
+        // std::array members are value-initialized (zeroed for uint8_t).
+    }
 
-    // Member functions
-    void Fixup();
-    int64_t CalculatePlaneData(int planeIndex);
-    void MakeBoxFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds);
+    /**
+     * Resolves raw offsets to pointers. Populates pFaces, pPlanes, etc.
+     * The raw offsets are assumed to be relative to the base of this B4ConvexHull instance.
+     * @param baseOfThisStruct A char pointer to the starting address of this B4ConvexHull instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (m_offsetFaces_raw != 0) pFaces = reinterpret_cast<uint8_t*>(baseOfThisStruct + m_offsetFaces_raw);
+        else pFaces = nullptr;
+
+        if (m_offsetPlanes_raw != 0) pPlanes = reinterpret_cast<uint8_t*>(baseOfThisStruct + m_offsetPlanes_raw);
+        else pPlanes = nullptr;
+
+        if (m_offsetVertices_raw != 0) pVertices = reinterpret_cast<uint8_t*>(baseOfThisStruct + m_offsetVertices_raw);
+        else pVertices = nullptr;
+
+        if (m_offsetEdges_raw != 0) pEdges = reinterpret_cast<uint8_t*>(baseOfThisStruct + m_offsetEdges_raw);
+        else pEdges = nullptr;
+
+        if (m_offsetDeformData_raw != 0) pDeformData = reinterpret_cast<uint8_t*>(baseOfThisStruct + m_offsetDeformData_raw);
+        else pDeformData = nullptr;
+    }
+
+    // Declarations for other member functions from the existing B4ConvexHull.h.
+    // These will be defined in B4ConvexHull.cpp and may need adaptation.
+    int64_t CalculatePlaneData(int planeIndex); // Implementation will need to use 'pPlanes', 'pFaces', 'pVertices'
+    void MakeBoxFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds); // Uses 'pVertices', 'pPlanes', 'pFaces', 'pEdges'
     void MakeFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds, EB4HullShape hullShape);
-    void MakeConeFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds);
-    void MakeBoatFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds);
-    bool DeformHullVerts(
-        GtMath::Vector3* pOutAveragePos, // Can be nullptr
+    void MakeConeFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds); // (TODO in original)
+    void MakeBoatFromBoundingBox(const GtMath::Vector3& minBounds, const GtMath::Vector3& maxBounds); // (TODO in original)
+    bool DeformHullVerts( // Uses 'pVertices', 'pDeformData'
+        GtMath::Vector3* pOutAveragePos,
         const GtMath::Vector3& refPositionForAverageCalc,
         const GtMath::Matrix3x4& deformMatrix,
-        const GtMath::Matrix3x4* pBoneMatrices, // Array of bone matrices
-        const B4ConvexHull& originalHull      // Undeformed hull
+        const GtMath::Matrix3x4* pBoneMatrices,
+        const B4ConvexHull& originalHull // originalHull.pVertices etc.
     );
-    void MakePlanar();
-    void DebugRenderEdges(const GtMath::Matrix3x4& worldTransform, bool drawText) const;
-    void DebugRenderPlanes(const GtMath::Matrix3x4& worldTransform, bool drawText) const;
-    void InitialiseVehicleHull();
-
-    // Placeholder for other member functions to be added later
-    // For example:
-    // const GtMath::Vector3* getVertices() const;
-    // const GtMath::Plane* getPlanes() const;
-    // ... other getters and utility functions
+    void MakePlanar(); // Uses 'pVertices', 'pPlanes'
+    void DebugRenderEdges(const GtMath::Matrix3x4& worldTransform, bool drawText) const; // Uses 'pVertices', 'pEdges'
+    void DebugRenderPlanes(const GtMath::Matrix3x4& worldTransform, bool drawText) const; // Uses 'pVertices', 'pPlanes', 'pFaces'
+    void InitialiseVehicleHull(); // Will call FixUp((char*)this);
 };
 
-#endif // B4_CONVEX_HULL_H
+// Verify structure size:
+// 5 * sizeof(uint32_t) for raw offsets = 20 bytes
+// sizeof(uint32_t) for m_flags = 4 bytes
+// 4 * sizeof(uint8_t) for counts/padding = 4 bytes
+// std::array<uint8_t, 68> for m_faceData_embed = 68 bytes
+// std::array<uint8_t, 224> for m_planeData_embed = 224 bytes
+// std::array<uint8_t, 256> for m_vertexData_embed = 256 bytes
+// std::array<uint8_t, 56> for m_edgeData_embed = 56 bytes
+// std::array<uint8_t, 200> for m_deformData_embed = 200 bytes
+// Total = 20 + 4 + 4 + 68 + 224 + 256 + 56 + 200 = 832 bytes (0x340).
+// This matches the original C struct's sizeof.
+// The pointer members (pFaces, pPlanes, etc.) do not contribute to this size calculation
+// as they are for post-FixUp C++ access and are not part of the serialized layout.
+
+} // namespace Burnout4

--- a/src/B4ModelData.h
+++ b/src/B4ModelData.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include <cstdint> // For intptr_t if needed, though char* arithmetic is used here.
+
+namespace Burnout4 {
+
+// Original C struct:
+// struct __attribute__((packed)) B4ModelData::SubMeshData // sizeof=0x8
+// {
+//     int pVertices_offset;
+//     int pIndices_offset;
+// };
+struct SubMeshData {
+    int pVertices_offset; // Offset from the start of this SubMeshData instance to vertex data
+    int pIndices_offset;  // Offset from the start of this SubMeshData instance to index data
+
+    // Pointers to be resolved by FixUp.
+    // These will point to the actual vertex and index data after FixUp.
+    void* pVertices;
+    void* pIndices;
+
+    SubMeshData() : pVertices_offset(0), pIndices_offset(0), pVertices(nullptr), pIndices(nullptr) {}
+
+    /**
+     * Resolves internal offsets to pointers, assuming this SubMeshData instance is part of a data block.
+     * @param baseOfThisStruct A pointer to the beginning of this SubMeshData instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pVertices_offset != 0) {
+            // The C code implies offsets are relative to the start of the struct itself.
+            // e.g., vertex_data_ptr = (char*)this + this->pVertices_offset;
+            pVertices = baseOfThisStruct + pVertices_offset;
+        } else {
+            pVertices = nullptr;
+        }
+
+        if (pIndices_offset != 0) {
+            // e.g., index_data_ptr = (char*)this + this->pIndices_offset;
+            pIndices = baseOfThisStruct + pIndices_offset;
+        } else {
+            pIndices = nullptr;
+        }
+    }
+};
+
+// Original C struct:
+// struct __attribute__((packed)) B4ModelData // sizeof=0x10
+// {
+//     int numSubMeshes;
+//     int pSubMeshes_offset;
+//     struct B4ModelData::SubMeshData m_subMeshes[1]; // This was a flexible array member hint
+// };
+struct B4ModelData {
+    int numSubMeshes;
+    int pSubMeshes_offset; // Offset from the start of this B4ModelData instance to the array of SubMeshData
+
+    // Pointer to an array of SubMeshData, to be resolved by FixUp.
+    // This will point to the actual SubMeshData array after FixUp.
+    SubMeshData* m_subMeshes;
+
+    B4ModelData() : numSubMeshes(0), pSubMeshes_offset(0), m_subMeshes(nullptr) {}
+
+    /**
+     * Resolves internal offsets to pointers, assuming this B4ModelData instance is part of a data block.
+     * @param baseOfThisStruct A pointer to the beginning of this B4ModelData instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pSubMeshes_offset != 0) {
+            // The C code implies pSubMeshes_offset is relative to the start of B4ModelData.
+            // e.g., subMeshes_array_ptr = (SubMeshData*)((char*)this + this->pSubMeshes_offset);
+            m_subMeshes = reinterpret_cast<SubMeshData*>(baseOfThisStruct + pSubMeshes_offset);
+
+            // Now, FixUp each SubMeshData. Its offsets are relative to its own base.
+            for (int i = 0; i < numSubMeshes; ++i) {
+                m_subMeshes[i].FixUp(reinterpret_cast<char*>(&m_subMeshes[i]));
+            }
+        } else {
+            m_subMeshes = nullptr;
+        }
+    }
+};
+
+} // namespace Burnout4

--- a/src/B4SoundESM.h
+++ b/src/B4SoundESM.h
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <cstdint> // For int32_t, uint32_t, uint8_t
+#include <array>   // For std::array if fixed-size arrays are preferred for unknown_data
+
+namespace Burnout4 {
+
+// Original C struct:
+// struct B4SoundESMGraphStruct // sizeof=0x8
+// {
+//     float *pGraphDataPoints_offset; // Offset from B4SoundESMGraphStruct base
+//     int numDataPoints;
+// };
+struct B4SoundESMGraphStruct {
+    uint32_t pGraphDataPoints_offset_raw; // Raw 4-byte offset from the base of this struct
+    int32_t  numDataPoints;
+
+    // Resolved pointer (populated by FixUp)
+    float*   pGraphDataPoints;
+
+    B4SoundESMGraphStruct() :
+        pGraphDataPoints_offset_raw(0),
+        numDataPoints(0),
+        pGraphDataPoints(nullptr) {}
+
+    /**
+     * Resolves the internal offset to an actual pointer.
+     * @param baseOfThisStruct A char pointer to the starting address of this B4SoundESMGraphStruct instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pGraphDataPoints_offset_raw != 0) {
+            // Offset is relative to the start of this B4SoundESMGraphStruct instance
+            pGraphDataPoints = reinterpret_cast<float*>(baseOfThisStruct + pGraphDataPoints_offset_raw);
+        } else {
+            pGraphDataPoints = nullptr;
+        }
+    }
+};
+// Size of data part: 4 (offset_raw) + 4 (numDataPoints) = 8 bytes. Matches.
+
+// Forward declaration for recursive structures if split across files (not needed here)
+// struct B4SoundESMGraphStruct;
+
+// Original C struct:
+// struct B4SoundESMPartialStruct // sizeof=0x10
+// {
+//     unsigned __int8 unknown_partial_data[8];
+//     B4SoundESMGraphStruct *pGraphs_offset; // Offset from B4SoundESMPartialStruct base
+//     unsigned __int8 numGraphs;
+//     unsigned __int8 unk_D;
+//     unsigned __int8 unk_E;
+//     unsigned __int8 unk_F;
+// };
+struct B4SoundESMPartialStruct {
+    std::array<uint8_t, 8> unknown_partial_data; // Using std::array for fixed size
+    uint32_t pGraphs_offset_raw; // Raw 4-byte offset from the base of this struct to an array of B4SoundESMGraphStruct
+    uint8_t  numGraphs;
+    uint8_t  unk_D;
+    uint8_t  unk_E;
+    uint8_t  unk_F;
+
+    // Resolved pointer (populated by FixUp)
+    B4SoundESMGraphStruct* pGraphs;
+
+    B4SoundESMPartialStruct() :
+        pGraphs_offset_raw(0),
+        numGraphs(0),
+        unk_D(0),
+        unk_E(0),
+        unk_F(0),
+        pGraphs(nullptr) {
+        unknown_partial_data.fill(0);
+    }
+
+    /**
+     * Resolves internal offsets and calls FixUp on nested structures.
+     * @param baseOfThisStruct A char pointer to the starting address of this B4SoundESMPartialStruct instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pGraphs_offset_raw != 0) {
+            // Offset is relative to the start of this B4SoundESMPartialStruct instance
+            pGraphs = reinterpret_cast<B4SoundESMGraphStruct*>(baseOfThisStruct + pGraphs_offset_raw);
+            for (uint8_t i = 0; i < numGraphs; ++i) {
+                // Each B4SoundESMGraphStruct's FixUp is relative to its own base address
+                pGraphs[i].FixUp(reinterpret_cast<char*>(&pGraphs[i]));
+            }
+        } else {
+            pGraphs = nullptr;
+        }
+    }
+};
+// Size of data part: 8 (unknown_data) + 4 (offset_raw) + 1 (numGraphs) + 1 (unk_D) + 1 (unk_E) + 1 (unk_F) = 16 bytes. Matches.
+
+// struct B4SoundESMPartialStruct; // Forward declaration
+
+// Original C struct:
+// struct __attribute__((packed)) B4SoundESMStruct // sizeof=0x44
+// {
+//     unsigned __int8 unknown_header_data[60]; // 0x3C bytes
+//     B4SoundESMPartialStruct *pPartials_offset; // Offset from B4SoundESMStruct base
+//     unsigned __int8 numPartials;
+//     unsigned __int8 unk_41;
+//     unsigned __int8 unk_42;
+//     unsigned __int8 unk_43;
+// };
+struct B4SoundESMStruct {
+    std::array<uint8_t, 60> unknown_header_data; // Using std::array
+    uint32_t pPartials_offset_raw; // Raw 4-byte offset from the base of this struct to an array of B4SoundESMPartialStruct
+    uint8_t  numPartials;
+    uint8_t  unk_41;
+    uint8_t  unk_42;
+    uint8_t  unk_43;
+
+    // Resolved pointer (populated by FixUp)
+    B4SoundESMPartialStruct* pPartials;
+
+    B4SoundESMStruct() :
+        pPartials_offset_raw(0),
+        numPartials(0),
+        unk_41(0),
+        unk_42(0),
+        unk_43(0),
+        pPartials(nullptr) {
+        unknown_header_data.fill(0);
+    }
+
+    /**
+     * Resolves internal offsets and calls FixUp on nested structures.
+     * @param baseOfThisStruct A char pointer to the starting address of this B4SoundESMStruct instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pPartials_offset_raw != 0) {
+            // Offset is relative to the start of this B4SoundESMStruct instance
+            pPartials = reinterpret_cast<B4SoundESMPartialStruct*>(baseOfThisStruct + pPartials_offset_raw);
+            for (uint8_t i = 0; i < numPartials; ++i) {
+                // Each B4SoundESMPartialStruct's FixUp is relative to its own base address
+                pPartials[i].FixUp(reinterpret_cast<char*>(&pPartials[i]));
+            }
+        } else {
+            pPartials = nullptr;
+        }
+    }
+};
+// Size of data part: 60 (unknown_data) + 4 (offset_raw) + 1 (numPartials) + 1 (unk_41) + 1 (unk_42) + 1 (unk_43) = 68 bytes (0x44). Matches.
+
+} // namespace Burnout4

--- a/src/B4VehicleLODDataBase.h
+++ b/src/B4VehicleLODDataBase.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include "B4ModelData.h" // For Burnout4::B4ModelData
+#include <cstdint>       // For uint32_t
+
+namespace Burnout4 {
+
+// Original C struct definition:
+// struct __attribute__((packed)) B4VehicleLODDataBase // sizeof=0x30
+// {
+//     B4ModelData *pMainModel_offset;    // Expected to be a 4-byte offset
+//     B4ModelData *pWheelModels_offset[8]; // Expected to be 4-byte offsets
+//     B4ModelData *pGlassModels_offset[3]; // Expected to be 4-byte offsets
+// };
+// Total size in C: 4 (for pMainModel_offset) + 8*4 (for pWheelModels_offset) + 3*4 (for pGlassModels_offset) = 48 bytes (0x30).
+
+struct B4VehicleLODDataBase {
+    // These fields represent the on-disk or original memory layout.
+    // They store 4-byte offsets relative to the beginning of this struct.
+    uint32_t mainModelOffset;
+    uint32_t wheelModelsOffset[8];
+    uint32_t glassModelsOffset[3];
+
+    // These pointers are for C++ convenience after FixUp has been called.
+    // They are not part of the original 0x30 byte data structure.
+    B4ModelData* pMainModel;
+    B4ModelData* pWheelModels[8];
+    B4ModelData* pGlassModels[3];
+
+    B4VehicleLODDataBase() :
+        mainModelOffset(0),
+        pMainModel(nullptr) {
+
+        for (int i = 0; i < 8; ++i) {
+            wheelModelsOffset[i] = 0;
+            pWheelModels[i] = nullptr;
+        }
+        for (int i = 0; i < 3; ++i) {
+            glassModelsOffset[i] = 0;
+            pGlassModels[i] = nullptr;
+        }
+    }
+
+    /**
+     * Resolves the stored offsets and populates the B4ModelData pointers.
+     * This method assumes that the '*Offset' fields have been loaded with
+     * the raw 4-byte offset values from the game data.
+     * @param baseOfThisStruct A char pointer to the starting address of this
+     *                         B4VehicleLODDataBase instance in memory.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        // Resolve main model
+        if (mainModelOffset != 0) {
+            // Calculate the actual address of the main model
+            pMainModel = reinterpret_cast<B4ModelData*>(baseOfThisStruct + mainModelOffset);
+            // Call FixUp on the main model, its offsets are relative to its own address
+            pMainModel->FixUp(reinterpret_cast<char*>(pMainModel));
+        } else {
+            pMainModel = nullptr;
+        }
+
+        // Resolve wheel models
+        for (int i = 0; i < 8; ++i) {
+            if (wheelModelsOffset[i] != 0) {
+                pWheelModels[i] = reinterpret_cast<B4ModelData*>(baseOfThisStruct + wheelModelsOffset[i]);
+                pWheelModels[i]->FixUp(reinterpret_cast<char*>(pWheelModels[i]));
+            } else {
+                pWheelModels[i] = nullptr;
+            }
+        }
+
+        // Resolve glass models
+        for (int i = 0; i < 3; ++i) {
+            if (glassModelsOffset[i] != 0) {
+                pGlassModels[i] = reinterpret_cast<B4ModelData*>(baseOfThisStruct + glassModelsOffset[i]);
+                pGlassModels[i]->FixUp(reinterpret_cast<char*>(pGlassModels[i]));
+            } else {
+                pGlassModels[i] = nullptr;
+            }
+        }
+    }
+};
+
+// Verify that the part of the struct corresponding to the original C struct layout is 0x30 bytes.
+// sizeof(uint32_t) + sizeof(uint32_t[8]) + sizeof(uint32_t[3])
+// = 4 + (8 * 4) + (3 * 4) = 4 + 32 + 12 = 48 bytes.
+// This matches the original sizeof=0x30.
+// The B4ModelData* members are additional and do not affect this initial layout size.
+
+} // namespace Burnout4

--- a/src/B4VehiclePayloadSet.h
+++ b/src/B4VehiclePayloadSet.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <cstdint> // For int32_t, uint32_t
+
+namespace Burnout4 {
+
+// Original C struct definition:
+// struct __attribute__((packed)) B4VehiclePayloadSet // sizeof=0xC
+// {
+//     int m_payloadType;
+//     int m_numAttachmentPoints;
+//     void *pAttachmentPointsData_offset; // Offset from B4VehiclePayloadSet base
+// };
+
+struct B4VehiclePayloadSet {
+    // These fields represent the on-disk or original memory layout.
+    int32_t  m_payloadType;
+    int32_t  m_numAttachmentPoints;
+    uint32_t pAttachmentPointsData_offset_raw; // Raw 4-byte offset from the base of this struct
+
+    // Resolved pointer for C++ convenience (populated by FixUp).
+    // This is not part of the original 0xC byte data structure.
+    void*    pAttachmentPointsData;
+
+    B4VehiclePayloadSet() :
+        m_payloadType(0),
+        m_numAttachmentPoints(0),
+        pAttachmentPointsData_offset_raw(0),
+        pAttachmentPointsData(nullptr) {}
+
+    /**
+     * Resolves the internal offset (pAttachmentPointsData_offset_raw) to an actual pointer (pAttachmentPointsData).
+     * This method assumes that pAttachmentPointsData_offset_raw has been loaded with
+     * the raw 4-byte offset value from the game data.
+     * @param baseOfThisStruct A char pointer to the starting address of this
+     *                         B4VehiclePayloadSet instance in memory.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pAttachmentPointsData_offset_raw != 0) {
+            pAttachmentPointsData = reinterpret_cast<void*>(baseOfThisStruct + pAttachmentPointsData_offset_raw);
+        } else {
+            pAttachmentPointsData = nullptr;
+        }
+    }
+};
+
+// Verify that the part of the struct corresponding to the original C struct layout is 0xC bytes.
+// sizeof(m_payloadType) (int32_t) = 4 bytes
+// sizeof(m_numAttachmentPoints) (int32_t) = 4 bytes
+// sizeof(pAttachmentPointsData_offset_raw) (uint32_t) = 4 bytes
+// Total = 4 + 4 + 4 = 12 bytes (0xC).
+// This matches the original sizeof.
+// The pAttachmentPointsData pointer member is additional and does not affect this initial layout size.
+
+} // namespace Burnout4

--- a/src/GtTexture.h
+++ b/src/GtTexture.h
@@ -1,0 +1,163 @@
+#pragma once
+
+#include <cstdint> // For uint32_t, uint8_t
+#include <vector>  // Potentially for std::vector if we store resolved arrays
+
+namespace Burnout4 {
+
+// Forward declaration for GtTexture if GtTextureSubDefinition needs it (not in this case)
+// struct GtTexture;
+
+// Original C struct:
+// struct __attribute__((packed)) GtTextureSubDefinition // sizeof=0x10
+// {
+//     unsigned int sub_def_flags;
+//     void *pPixelDataForSubDef_offset; // Offset from GtTexture base
+//     unsigned __int8 sub_def_padding[8];
+// };
+struct GtTextureSubDefinition {
+    uint32_t sub_def_flags; // If this is the first sub-definition in an array pointed to by GtTexture, this holds the count. Otherwise, flags.
+    uint32_t pPixelDataForSubDef_offset; // Offset from the base of the parent GtTexture struct
+    uint8_t  sub_def_padding[8];
+
+    // Resolved pointer (populated by FixUp)
+    void*    pPixelDataForSubDef;
+
+    GtTextureSubDefinition() :
+        sub_def_flags(0),
+        pPixelDataForSubDef_offset(0),
+        pPixelDataForSubDef(nullptr) {
+        for(int i = 0; i < 8; ++i) {
+            sub_def_padding[i] = 0;
+        }
+    }
+
+    /**
+     * Resolves the internal offset to an actual pointer.
+     * @param baseOfParentGtTexture A char pointer to the starting address of the parent GtTexture instance.
+     */
+    void FixUp(char* baseOfParentGtTexture) {
+        if (pPixelDataForSubDef_offset != 0) {
+            pPixelDataForSubDef = baseOfParentGtTexture + pPixelDataForSubDef_offset;
+        } else {
+            pPixelDataForSubDef = nullptr;
+        }
+        // sub_def_flags is a value, not an offset to be fixed up.
+    }
+};
+// Size of GtTextureSubDefinition's data part: 4 (flags) + 4 (offset) + 8 (padding) = 16 bytes (0x10).
+
+// Original C struct:
+// struct __attribute__((packed)) GtTexture // sizeof=0xA8
+// {
+//     void *pPixelData_offset;
+//     void *pClutData_offset;
+//     void *pMipmapData_offset;
+//     unsigned __int8 unknown_data_0C_to_23[24];
+//     GtTextureSubDefinition *pSubDefinitions_offset;
+//     unsigned __int8 unknown_data_0x28_to_0x6B[68];
+//     char *pTextureName_offset;
+//     void *pGsRamClutPtrs_offset[7];
+//     char pad_8C[24];
+//     void *unk_A4; // Note: C struct uses unk_A4, implies it's an offset field
+// };
+struct GtTexture {
+    // These fields represent the on-disk or original memory layout (0xA8 bytes).
+    // All offsets are relative to the beginning of this GtTexture struct.
+    uint32_t pPixelData_offset;
+    uint32_t pClutData_offset;
+    uint32_t pMipmapData_offset;
+    uint8_t  unknown_data_0C_to_23[24];
+    uint32_t pSubDefinitions_offset;         // Offset to an array of GtTextureSubDefinition
+    uint8_t  unknown_data_0x28_to_0x6B[68];
+    uint32_t pTextureName_offset;
+    uint32_t pGsRamClutPtrs_offset[7];
+    uint8_t  pad_8C[24];
+    uint32_t unk_A4_offset;                  // Named consistently as an offset
+
+    // Resolved Pointers (for C++ convenience, not part of the 0xA8 layout)
+    void*                   pPixelData;
+    void*                   pClutData;
+    void*                   pMipmapData;
+    GtTextureSubDefinition* pSubDefinitions; // Points to an array after FixUp
+    char*                   pTextureName;
+    void*                   pGsRamClutPtrs[7];
+    void*                   unk_A4;
+
+    uint32_t numSubDefinitions; // Stores the count of sub-definitions
+
+    GtTexture() :
+        pPixelData_offset(0), pClutData_offset(0), pMipmapData_offset(0),
+        pSubDefinitions_offset(0), pTextureName_offset(0), unk_A4_offset(0),
+        pPixelData(nullptr), pClutData(nullptr), pMipmapData(nullptr),
+        pSubDefinitions(nullptr), pTextureName(nullptr), unk_A4(nullptr),
+        numSubDefinitions(0) {
+
+        for(int i = 0; i < 24; ++i) unknown_data_0C_to_23[i] = 0;
+        for(int i = 0; i < 68; ++i) unknown_data_0x28_to_0x6B[i] = 0;
+        for(int i = 0; i < 7; ++i) {
+            pGsRamClutPtrs_offset[i] = 0;
+            pGsRamClutPtrs[i] = nullptr;
+        }
+        for(int i = 0; i < 24; ++i) pad_8C[i] = 0;
+    }
+
+    /**
+     * Resolves all internal offsets to actual pointers.
+     * @param baseOfThisStruct A char pointer to the starting address of this GtTexture instance.
+     */
+    void FixUp(char* baseOfThisStruct) {
+        if (pPixelData_offset != 0) pPixelData = baseOfThisStruct + pPixelData_offset;
+        else pPixelData = nullptr;
+
+        if (pClutData_offset != 0) pClutData = baseOfThisStruct + pClutData_offset;
+        else pClutData = nullptr;
+
+        if (pMipmapData_offset != 0) pMipmapData = baseOfThisStruct + pMipmapData_offset;
+        else pMipmapData = nullptr;
+
+        if (pTextureName_offset != 0) pTextureName = reinterpret_cast<char*>(baseOfThisStruct + pTextureName_offset);
+        else pTextureName = nullptr;
+
+        if (unk_A4_offset != 0) unk_A4 = baseOfThisStruct + unk_A4_offset;
+        else unk_A4 = nullptr;
+
+        for (int i = 0; i < 7; ++i) {
+            if (pGsRamClutPtrs_offset[i] != 0) {
+                pGsRamClutPtrs[i] = baseOfThisStruct + pGsRamClutPtrs_offset[i];
+            } else {
+                pGsRamClutPtrs[i] = nullptr;
+            }
+        }
+
+        if (pSubDefinitions_offset != 0) {
+            pSubDefinitions = reinterpret_cast<GtTextureSubDefinition*>(baseOfThisStruct + pSubDefinitions_offset);
+
+            // According to original FixUp: "recordCount = pTexture->pSubDefinitions_offset->sub_def_flags;"
+            // This means the sub_def_flags of the *first* GtTextureSubDefinition object in the array holds the count.
+            if (pSubDefinitions) { // Check if the pointer is valid after resolving offset
+                numSubDefinitions = pSubDefinitions[0].sub_def_flags;
+
+                // Now FixUp each GtTextureSubDefinition in the array.
+                // Their pPixelDataForSubDef_offset is relative to the base of this GtTexture.
+                for (uint32_t i = 0; i < numSubDefinitions; ++i) {
+                    pSubDefinitions[i].FixUp(baseOfThisStruct);
+                }
+            } else {
+                // Should not happen if pSubDefinitions_offset was non-zero, but defensive.
+                numSubDefinitions = 0;
+            }
+        } else {
+            pSubDefinitions = nullptr;
+            numSubDefinitions = 0;
+        }
+    }
+};
+
+// Verify GtTexture's data part size:
+// uint32_t fields: pPixelData_offset (4), pClutData_offset (4), pMipmapData_offset (4),
+//                   pSubDefinitions_offset (4), pTextureName_offset (4),
+//                   pGsRamClutPtrs_offset[7] (28), unk_A4_offset (4)
+// uint8_t arrays: unknown_data_0C_to_23[24] (24), unknown_data_0x28_to_0x6B[68] (68), pad_8C[24] (24)
+// Total = 4+4+4+24+4+68+4+28+24+4 = 168 bytes (0xA8). Matches original sizeof.
+} // namespace Burnout4


### PR DESCRIPTION
This commit introduces C++ reimplementations of several C structs originally found in decompiled/B4VehicleData_Decomp.c. The goal is to mirror the original PS2 memory layouts while providing C++-friendly interfaces with 'FixUp' methods to resolve internal data offsets into usable pointers.

Changes include:
- src/GtMath.h: Identified existing GtMath::Matrix3x4 and GtMath::Vector4 as suitable replacements for GtMatrix3x4 and GtV3d.
- src/B4ModelData.h: Added B4ModelData and B4ModelData::SubMeshData.
- src/B4VehicleLODDataBase.h: Added B4VehicleLODDataBase.
- src/GtTexture.h: Added GtTextureSubDefinition and GtTexture.
- src/B4ConvexHull.h: Refactored to use std::array for embedded data, matching the C struct's 0x340 byte layout.
- src/B4ConvexHull.cpp: Updated methods to use new data members.
- src/B4VehiclePayloadSet.h: Added B4VehiclePayloadSet.
- src/B4SoundESM.h: Added B4SoundESMGraphStruct, B4SoundESMPartialStruct, and B4SoundESMStruct with hierarchical FixUp logic.

All new structures are placed within the Burnout4 namespace and designed to ensure their data layout matches the original C struct sizes by using uint32_t for raw offsets and std::array for fixed-size embedded data. Resolved pointers are provided for C++ convenience after FixUp.

The main B4VehicleData struct implementation is the next step.